### PR TITLE
Fix: openseadragon 3.0 API

### DIFF
--- a/src/imagefilters.js
+++ b/src/imagefilters.js
@@ -120,7 +120,7 @@
         $.extend(true, this.navImages, this.viewer.navImages);
 
         var prefix = this.prefixUrl || this.viewer.prefixUrl || '';
-        var useGroup = this.viewer.buttons && this.viewer.buttons.buttons;
+        var useGroup = this.viewer.buttonGroup && this.viewer.buttonGroup.buttons;
 
         if (this.showControl) {
             this.toggleButton = new $.Button({
@@ -136,8 +136,8 @@
             });
 
             if (useGroup) {
-                this.viewer.buttons.buttons.push(this.toggleButton);
-                this.viewer.buttons.element.appendChild(this.toggleButton.element);
+                this.viewer.buttonGroup.buttons.push(this.toggleButton);
+                this.viewer.buttonGroup.element.appendChild(this.toggleButton.element);
             }
             if (this.toggleButton.imgDown) {
                 this.buttonActiveImg = this.toggleButton.imgDown.cloneNode(true);


### PR DESCRIPTION
Hello,

In openseadragon 3.0 `viewer.buttons` was renamed to `viewer.buttonGroup`, breaking the plugin:
https://github.com/openseadragon/openseadragon/commit/0ede8992de954e2a1641b7ce60fb865d3c3849a8

For backward-compat you may want to allow any of the 2 APIs... The MR is mainly there to tell you about this, feel free to fix in a different commit.

Have a good day and thanks a lot for this useful plugin!

> see also https://github.com/picturae/openseadragonselection/pull/50